### PR TITLE
Improved failure handling

### DIFF
--- a/src/main/scala/com/gilt/gfc/aws/s3/akka/S3UploaderSink.scala
+++ b/src/main/scala/com/gilt/gfc/aws/s3/akka/S3UploaderSink.scala
@@ -63,9 +63,10 @@ class S3MultipartUploaderSinkProtocol(
   }
 
   def abortUpload(ex: Throwable, state: S3MultipartUploaderState): Unit = {
-    logger.info(s"Something happened during the execution, the upload has to be aborted", ex)
-    val request = new AbortMultipartUploadRequest(bucketName, key, state.uploadId)
-    s3Client.abortMultipartUpload(request)
+    logger.error(s"Something happened during the execution, the upload has to be aborted", ex)
+    s3Client.abortMultipartUpload(
+      new AbortMultipartUploadRequest(bucketName, key, state.uploadId)
+    )
     logger.info(s"Upload aborted for ${state.uploadId}")
   }
 


### PR DESCRIPTION
When exception happens during the upload process on the client side, it would lead to incorrect upload finish (closing either unopened or incomplete file). This patch handles downstream failure in a correct manner - by intentionally aborting incomplete upload.